### PR TITLE
refactor: move supabase config to server

### DIFF
--- a/netlify/functions/fetch-rss.ts
+++ b/netlify/functions/fetch-rss.ts
@@ -1,0 +1,62 @@
+import type { Handler } from '@netlify/functions';
+
+const headers = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 200,
+      headers,
+      body: '',
+    };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers,
+      body: JSON.stringify({ error: 'Method not allowed' }),
+    };
+  }
+
+  try {
+    const { feedUrl } = JSON.parse(event.body || '{}');
+    if (!feedUrl) {
+      return {
+        statusCode: 400,
+        headers,
+        body: JSON.stringify({ error: 'Feed URL is required' }),
+      };
+    }
+
+    const response = await fetch(feedUrl, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; RSS-Reader/1.0)',
+        'Accept': 'application/rss+xml, application/xml, text/xml',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const contents = await response.text();
+
+    return {
+      statusCode: 200,
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents }),
+    };
+  } catch (error: any) {
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: `Failed to fetch RSS feed: ${error.message}` }),
+    };
+  }
+};
+

--- a/netlify/functions/supabase-config.ts
+++ b/netlify/functions/supabase-config.ts
@@ -1,0 +1,16 @@
+import type { Handler } from '@netlify/functions';
+
+export const handler: Handler = async () => {
+  const url = process.env.VITE_SUPABASE_URL || '';
+  const anonKey = process.env.VITE_SUPABASE_ANON_KEY || '';
+
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+    },
+    body: JSON.stringify({ url, anonKey }),
+  };
+};
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { useProjects, useIdeas, useDrafts, usePublications } from './hooks/useSu
 import { useToast } from './hooks/useToast';
 import { generateContent } from './lib/openai';
 import { ViewMode, Project, Idea, Draft } from './types';
+import { isSupabaseConfigured } from './lib/supabase';
 
 function AppContent() {
   const [currentView, setCurrentView] = useState<ViewMode>('projects');
@@ -34,9 +35,6 @@ function AppContent() {
   
   const [activeProject, setActiveProject] = useState<Project | null>(null);
   
-  // Check if Supabase is configured
-  const isSupabaseConfigured = !!(import.meta.env.VITE_SUPABASE_URL && import.meta.env.VITE_SUPABASE_ANON_KEY);
-
   // Show configuration message if Supabase is not configured
   if (!isSupabaseConfigured) {
     return (

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Mail, Lock, Eye, EyeOff, AlertCircle, X, AlertTriangle } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
+import { isSupabaseConfigured } from '../lib/supabase';
 
 interface AuthFormProps {
   onClose?: () => void;
@@ -24,8 +25,8 @@ export function AuthForm({ onClose }: AuthFormProps) {
     setSuccess(null);
 
     // Check if Supabase is configured
-    if (!import.meta.env.VITE_SUPABASE_URL || !import.meta.env.VITE_SUPABASE_ANON_KEY) {
-      setError('La aplicación no está configurada correctamente. Las variables de entorno de Supabase no están disponibles. Por favor, contacta al administrador para configurar VITE_SUPABASE_URL y VITE_SUPABASE_ANON_KEY en Netlify.');
+    if (!isSupabaseConfigured) {
+      setError('La aplicación no está configurada correctamente. Las variables de entorno de Supabase no están disponibles. Por favor, contacta al administrador para configurarlas en el servidor.');
       setLoading(false);
       return;
     }
@@ -116,7 +117,7 @@ export function AuthForm({ onClose }: AuthFormProps) {
           </div>
 
           {/* Configuration Warning */}
-          {(!import.meta.env.VITE_SUPABASE_URL || !import.meta.env.VITE_SUPABASE_ANON_KEY) && (
+          {!isSupabaseConfigured && (
             <div className="mb-6 p-4 bg-gray-800/30 border border-gray-700/40 rounded-lg animate-fade-in">
               <div className="flex items-center space-x-3">
                 <AlertTriangle className="w-5 h-5 text-gray-300 flex-shrink-0" />

--- a/src/lib/rssParser.ts
+++ b/src/lib/rssParser.ts
@@ -88,13 +88,10 @@ function parseRSSXML(xmlText: string, feedUrl: string): RSSItem[] {
 // Fetch RSS feed through CORS proxy
 export async function fetchRSSFeed(feedUrl: string): Promise<RSSFeed> {
   try {
-    // Use Supabase Edge Function to fetch RSS feeds
-    const apiUrl = `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/fetch-rss`;
-    
-    const response = await fetch(apiUrl, {
+    // Use server-side function to fetch RSS feeds
+    const response = await fetch('/api/fetch-rss', {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ feedUrl }),

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,42 +1,46 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
 let supabase: any;
+let isSupabaseConfigured = false;
 
-// In production, show a user-friendly message instead of throwing
-if (!supabaseUrl || !supabaseAnonKey) {
-  console.error('Missing Supabase environment variables. Please configure VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in Netlify.');
-  
-  // Create a mock client that will show helpful error messages
-  supabase = {
-    auth: {
-      getSession: () => Promise.resolve({ data: { session: null }, error: null }),
-      onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
-      signInWithPassword: () => Promise.resolve({ error: { message: 'Supabase no está configurado. Contacta al administrador.' } }),
-      signUp: () => Promise.resolve({ error: { message: 'Supabase no está configurado. Contacta al administrador.' } }),
-      signOut: () => Promise.resolve({ error: null })
-    },
-    from: () => ({
-      select: () => ({ order: () => Promise.resolve({ data: [], error: null }) }),
-      insert: () => ({ select: () => ({ single: () => Promise.resolve({ data: null, error: { message: 'Supabase no está configurado' } }) }) }),
-      update: () => ({ eq: () => ({ select: () => ({ single: () => Promise.resolve({ data: null, error: { message: 'Supabase no está configurado' } }) }) }) }),
-      delete: () => ({ eq: () => Promise.resolve({ error: { message: 'Supabase no está configurado' } }) })
-    })
-  };
-} else {
-  // Validate URL format
+async function initSupabase() {
   try {
-    new URL(supabaseUrl);
-  } catch (error) {
-    throw new Error(`Invalid VITE_SUPABASE_URL format: "${supabaseUrl}". Must be a complete URL like https://your-project-id.supabase.co`);
-  }
+    const res = await fetch('/api/supabase-config');
+    if (!res.ok) throw new Error('Missing config');
+    const { url, anonKey } = await res.json();
 
-  supabase = createClient(supabaseUrl, supabaseAnonKey);
+    if (!url || !anonKey) throw new Error('Missing config');
+
+    // Validate URL format
+    new URL(url);
+
+    supabase = createClient(url, anonKey);
+    isSupabaseConfigured = true;
+  } catch (error) {
+    console.error('Missing Supabase environment variables. Please configure them on the server.');
+
+    // Create a mock client that will show helpful error messages
+    supabase = {
+      auth: {
+        getSession: () => Promise.resolve({ data: { session: null }, error: null }),
+        onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
+        signInWithPassword: () => Promise.resolve({ error: { message: 'Supabase no está configurado. Contacta al administrador.' } }),
+        signUp: () => Promise.resolve({ error: { message: 'Supabase no está configurado. Contacta al administrador.' } }),
+        signOut: () => Promise.resolve({ error: null })
+      },
+      from: () => ({
+        select: () => ({ order: () => Promise.resolve({ data: [], error: null }) }),
+        insert: () => ({ select: () => ({ single: () => Promise.resolve({ data: null, error: { message: 'Supabase no está configurado' } }) }) }),
+        update: () => ({ eq: () => ({ select: () => ({ single: () => Promise.resolve({ data: null, error: { message: 'Supabase no está configurado' } }) }) }) }),
+        delete: () => ({ eq: () => Promise.resolve({ error: { message: 'Supabase no está configurado' } }) })
+      })
+    };
+  }
 }
 
-export { supabase };
+await initSupabase();
+
+export { supabase, isSupabaseConfigured };
 
 export type Database = {
   public: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,7 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  build: {
+    target: 'esnext',
+  },
 });


### PR DESCRIPTION
## Summary
- initialize Supabase client from server-provided config and expose configuration status
- fetch RSS feeds and Supabase credentials through serverless Netlify functions
- set Vite build target to `esnext` to support async initialization

## Testing
- `npm run build`
- `rg -l VITE_SUPABASE_URL dist`
- `rg -l VITE_SUPABASE_ANON_KEY dist`
- `npm run lint` *(fails: no-unused-vars, no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_689627ce5e48832c973dee032fad6920